### PR TITLE
fix: monorepo option for github ALM

### DIFF
--- a/sonar/settings_service.go
+++ b/sonar/settings_service.go
@@ -143,7 +143,7 @@ type SettingsSetAlmOption struct {
 	AlmSetting string `url:"almSetting,omitempty"`
 	Project    string `url:"project,omitempty"`
 	Repository string `url:"repository,omitempty"`
-	Monorepo   bool   `url:"monorepo,omitempty"`
+	Monorepo   bool   `url:"monorepo"`
 }
 
 // SetGithubAlm sets the pull request decoration for GitHub on the given project


### PR DESCRIPTION
This change resolves an issue with setting the `monorepo` field in the `SettingsSetAlmOption{}` struct.

This is completed by removing the `omitempty` attribute from that field in the struct since it's a boolean.

Currently, I'm seeing the following behavior when attempting to use the `SetGithubAlm()` function:

```
time="2024-08-05T13:34:30Z" level=info msg="Setting up project" key=myOrg/myRepo team=myTeam user=myUser
time="2024-08-05T13:34:30Z" level=info msg="searching for existing project myOrg:myRepo"
time="2024-08-05T13:34:30Z" level=info msg="creating project myOrg:myRepo"
time="2024-08-05T13:34:33Z" level=info msg="setting decorations for project myOrg:myRepo"
time="2024-08-05T13:34:33Z" level=fatal msg="POST https://sonarqube.domain/api/: 400 {errors: [{msg: The 'monorepo' parameter is missing}]}"
```

The code that calls this function sets that field to `false` which leads to it not being provided due to `omitempty`.